### PR TITLE
HIP Port for AMD GPU (MI300X)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import platform
 import re
 import sys
 
+import torch
 from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
@@ -31,8 +32,13 @@ def main(debug: bool) -> None:
         ),
     }
 
-    nvcc_args = ["-O0", "-g", "-DDEBUG"] if debug else ["-O3", "--use_fast_math"]
-    if not os.getenv("TORCH_CUDA_ARCH_LIST"):
+    is_rocm_build = torch.version.hip is not None
+    nvcc_args = (
+        ["-O0", "-g", "-DDEBUG"]
+        if debug
+        else ["-O3", "-ffast-math" if is_rocm_build else "--use_fast_math"]
+    )
+    if not os.getenv("TORCH_CUDA_ARCH_LIST") and not is_rocm_build:
         # Respect TORCH_CUDA_ARCH_LIST when set, otherwise fall back to a default list of archs
         nvcc_args.extend(
             [
@@ -41,6 +47,12 @@ def main(debug: bool) -> None:
                 "-gencode=arch=compute_80,code=sm_80",
                 "-gencode=arch=compute_86,code=sm_86",
                 "-gencode=arch=compute_90,code=sm_90",
+            ]
+        )
+    if is_rocm_build:
+        nvcc_args.extend(
+            [
+                "-DHIP_ENABLE_WARP_SYNC_BUILTINS",
             ]
         )
 

--- a/src/include/cuda_math_helper.h
+++ b/src/include/cuda_math_helper.h
@@ -5,7 +5,11 @@
 
 #pragma once
 
+#if defined(__HIP_PLATFORM_AMD__) && (defined(__HIPCC__) || defined(__HIP__))
+#include <hip/hip_runtime.h>
+#else
 #include <cuda_runtime.h>
+#endif
 #include <algorithm>
 #include <cassert>
 #include <limits>
@@ -1130,6 +1134,11 @@ HD_FUNC double rnorm4d(double a, double b, double c, double d) {
   DEFINE_FUNC_FOR_UNSIGNED_INT(T, T2, T3, T4)     \
   ABS_FUNC(T, T2, T3, T4)
 
+#if defined(__HIP_PLATFORM_AMD__) && (defined(__HIPCC__) || defined(__HIP__))
+#define CUDA_MATH_HELPER_HAS_HIP_VECTOR_OPS
+#endif
+
+#ifndef CUDA_MATH_HELPER_HAS_HIP_VECTOR_OPS
 #define DEFINE_FUNC_FOR_FLOAT(T, T2, T3, T4) \
   UNARY_OP(T, T2, T3, T4)                    \
   BINARY_ARITHM_OP(T, T2, T3, T4)            \
@@ -1138,6 +1147,13 @@ HD_FUNC double rnorm4d(double a, double b, double c, double d) {
   OTHER_FUNC_FP(T, T2, T3, T4)               \
   ABS_FUNC(T, T2, T3, T4)                    \
   MAKE_FUNC(T, T2, T3, T4)
+#else
+#define DEFINE_FUNC_FOR_FLOAT(T, T2, T3, T4) \
+  OTHER_FUNC_ALL(T, T2, T3, T4)              \
+  OTHER_FUNC_FP(T, T2, T3, T4)               \
+  ABS_FUNC(T, T2, T3, T4)                    \
+  MAKE_FUNC(T, T2, T3, T4)
+#endif
 
 DEFINE_FUNC_FOR_UNSIGNED_INT(unsigned int, uint2, uint3, uint4);
 DEFINE_FUNC_FOR_SIGNED_INT(int, int2, int3, int4);

--- a/src/interpolate/interpolate_kernel.cu
+++ b/src/interpolate/interpolate_kernel.cu
@@ -137,12 +137,32 @@ __global__ void interpolate_backward_kernel(
 
   int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
 
+  constexpr int block_size = 256;
+#ifdef __HIP_PLATFORM_AMD__
+#ifdef __AMDGCN_WAVEFRONT_SIZE
+  constexpr int warp_size = __AMDGCN_WAVEFRONT_SIZE;
+#else
+  constexpr int warp_size = 64;
+#endif
+  using WarpMask = uint64_t;
+  constexpr WarpMask warp_mask = ~WarpMask{0};
+#else
   constexpr int warp_size = 32;
+  using WarpMask = unsigned;
+  constexpr WarpMask warp_mask = 0xFFFFFFFFU;
+#endif
+  // Keep the mask, shuffle width, and CUB logical warp size aligned. AMD CDNA
+  // wavefronts are 64 lanes, so treating them as 32-lane warps aliases lanes.
+  static_assert(block_size % warp_size == 0, "block_size must be divisible by warp_size");
+  constexpr int warps_per_block = block_size / warp_size;
+  using WarpReduce = cub::WarpReduce<scalar_t, warp_size>;
+
+  int warp_id = threadIdx.x / warp_size;
   int lane = threadIdx.x % warp_size;
 
-  __shared__ typename cub::WarpReduce<scalar_t>::TempStorage temp_storage_0;
-  __shared__ typename cub::WarpReduce<scalar_t>::TempStorage temp_storage_1;
-  __shared__ typename cub::WarpReduce<scalar_t>::TempStorage temp_storage_2;
+  __shared__ typename WarpReduce::TempStorage temp_storage_0[warps_per_block];
+  __shared__ typename WarpReduce::TempStorage temp_storage_1[warps_per_block];
+  __shared__ typename WarpReduce::TempStorage temp_storage_2[warps_per_block];
 
   {
     const index_t w = index % W;
@@ -159,9 +179,8 @@ __global__ void interpolate_backward_kernel(
         bary_img_grad.data + bary_img_grad_sN * n + bary_img_grad_sH * h + bary_img_grad_sW * w;
 
     bool thread_is_used = tr_index != -1;
-
     // True if at least one thread in the warp is used.
-    bool warp_is_used = __any_sync(0xFFFFFFFFU, thread_is_used);
+    bool warp_is_used = __any_sync(warp_mask, thread_is_used);
 
     if (warp_is_used) {
       int32_t vi_0 = -1, vi_1 = -1, vi_2 = -1;
@@ -171,13 +190,15 @@ __global__ void interpolate_backward_kernel(
         vi_1 = vi_ptr[1 * vi_sF];
         vi_2 = vi_ptr[2 * vi_sF];
       }
-      unsigned m = 0xFFFFFFFFU;
-      int vi_0_head = (__shfl_up_sync(m, vi_0, 1) != vi_0) || (lane == 0);
-      int vi_0_tail = (__shfl_down_sync(m, vi_0, 1) != vi_0) || (lane == (warp_size - 1));
-      int vi_1_head = (__shfl_up_sync(m, vi_1, 1) != vi_1) || (lane == 0);
-      int vi_1_tail = (__shfl_down_sync(m, vi_1, 1) != vi_1) || (lane == (warp_size - 1));
-      int vi_2_head = (__shfl_up_sync(m, vi_2, 1) != vi_2) || (lane == 0);
-      int vi_2_tail = (__shfl_down_sync(m, vi_2, 1) != vi_2) || (lane == (warp_size - 1));
+      int vi_0_head = (__shfl_up_sync(warp_mask, vi_0, 1, warp_size) != vi_0) || (lane == 0);
+      int vi_0_tail =
+          (__shfl_down_sync(warp_mask, vi_0, 1, warp_size) != vi_0) || (lane == (warp_size - 1));
+      int vi_1_head = (__shfl_up_sync(warp_mask, vi_1, 1, warp_size) != vi_1) || (lane == 0);
+      int vi_1_tail =
+          (__shfl_down_sync(warp_mask, vi_1, 1, warp_size) != vi_1) || (lane == (warp_size - 1));
+      int vi_2_head = (__shfl_up_sync(warp_mask, vi_2, 1, warp_size) != vi_2) || (lane == 0);
+      int vi_2_tail =
+          (__shfl_down_sync(warp_mask, vi_2, 1, warp_size) != vi_2) || (lane == (warp_size - 1));
 
       const scalar_t* __restrict vert_ptr = vert_attributes.data + vert_attributes_sN * n;
       const scalar_t* vert_0_ptr = vert_ptr + vert_attributes_sV * vi_0;
@@ -217,11 +238,11 @@ __global__ void interpolate_backward_kernel(
 
         if (vert_requires_grad) {
           scalar_t grad_v_0 =
-              cub::WarpReduce<scalar_t>(temp_storage_0).TailSegmentedSum(g_out * bary_0, vi_0_tail);
+              WarpReduce(temp_storage_0[warp_id]).TailSegmentedSum(g_out * bary_0, vi_0_tail);
           scalar_t grad_v_1 =
-              cub::WarpReduce<scalar_t>(temp_storage_1).TailSegmentedSum(g_out * bary_1, vi_1_tail);
+              WarpReduce(temp_storage_1[warp_id]).TailSegmentedSum(g_out * bary_1, vi_1_tail);
           scalar_t grad_v_2 =
-              cub::WarpReduce<scalar_t>(temp_storage_2).TailSegmentedSum(g_out * bary_2, vi_2_tail);
+              WarpReduce(temp_storage_2[warp_id]).TailSegmentedSum(g_out * bary_2, vi_2_tail);
 
           __syncthreads();
 


### PR DESCRIPTION
Only tested on MI300X w/ ROCm 6.2.2.
The build/installation steps are exactly the same as before, the main difference being the need for pytorch w/ ROCm binaries.

The two triangle test appears to work fine

Target:
![image](https://github.com/user-attachments/assets/ee398966-0248-40ac-8c7e-45e9ee572b23)
Mi300X result after 1980 iters:
![image](https://github.com/user-attachments/assets/ff96280e-90cb-4d6f-a6f3-781b819e1366)
