### PR TITLE
Fix missing CPU rasterize kernel in setup.py build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ def main(debug: bool) -> None:
                 sources=[
                     "src/rasterize/rasterize_module.cpp",
                     "src/rasterize/rasterize_kernel.cu",
+                    "src/rasterize/rasterize_kernel_cpu.cpp",
                 ],
                 extra_compile_args={"cxx": cxx_args[target_os], "nvcc": nvcc_args},
                 extra_link_args=extra_link_args[target_os],


### PR DESCRIPTION
The CPU implementation for the rasterize kernel (src/rasterize/rasterize_kernel_cpu.cpp) was added in 97455eb but was not included in the CUDAExtension sources list in setup.py. This causes an undefined symbol: _Z13rasterize_cpuRKN2at6TensorES2_llb error at import time with PyTorch 2.11+, which has stricter symbol resolution for dispatcher-registered implementations.

Fix: Add src/rasterize/rasterize_kernel_cpu.cpp to the sources list for drtk.rasterize_ext in setup.py.